### PR TITLE
Remove extra commas to avoid parse errors in IE

### DIFF
--- a/control/Permalink.js
+++ b/control/Permalink.js
@@ -3,7 +3,7 @@ L.Control.Permalink = L.Control.extend({
 		position: "bottomleft",
 		useAnchor: true,
 		useMarker: true,
-		markerOptions: {},
+		markerOptions: {}
 	},
 
 	initialize: function(layers, options) {
@@ -180,7 +180,7 @@ L.Control.Layers.include({
 			if (!obj.overlay && this._map.hasLayer(obj.layer))
 				return obj;
 		}
-	},
+	}
 });
 
 L.UrlUtil = {


### PR DESCRIPTION
Also allows minification by Google Closure Compiler et al, who would
otherwise refuse to work with it.
