### PR TITLE
Make Bing tile layer work over SSL.

### DIFF
--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -33,6 +33,7 @@ L.BingLayer = L.TileLayer.extend({
 			s = this.options.subdomains[Math.abs((p.x + p.y) % subdomains.length)];
 		return this._url.replace('{subdomain}', s)
 				.replace('{quadkey}', this.tile2quad(p.x, p.y, z))
+				.replace('http:', document.location.protocol)
 				.replace('{culture}', this.options.culture);
 	},
 
@@ -50,7 +51,7 @@ L.BingLayer = L.TileLayer.extend({
 			}
 			_this.initMetadata();
 		};
-		var url = "http://dev.virtualearth.net/REST/v1/Imagery/Metadata/" + this.options.type + "?include=ImageryProviders&jsonp=" + cbid + "&key=" + this._key;
+		var url = document.location.protocol + "//dev.virtualearth.net/REST/v1/Imagery/Metadata/" + this.options.type + "?include=ImageryProviders&jsonp=" + cbid + "&key=" + this._key;
 		var script = document.createElement("script");
 		script.type = "text/javascript";
 		script.src = url;


### PR DESCRIPTION
This avoids mixed content warnings caused by non-secure elements being loaded on a `https:` page.
