### PR TITLE
Check r.imageryProviders to prevent error when it is null

### DIFF
--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -63,6 +63,7 @@ L.BingLayer = L.TileLayer.extend({
 		this.options.subdomains = r.imageUrlSubdomains;
 		this._url = r.imageUrl;
 		this._providers = [];
+		if (r.imageryProviders) {
 		for (var i = 0; i < r.imageryProviders.length; i++) {
 			var p = r.imageryProviders[i];
 			for (var j = 0; j < p.coverageAreas.length; j++) {
@@ -76,6 +77,7 @@ L.BingLayer = L.TileLayer.extend({
 				coverage.attrib = p.attribution;
 				this._providers.push(coverage);
 			}
+		}
 		}
 		this._update();
 	},


### PR DESCRIPTION
I use leaflet and your bing maps plugin so that I can display Ordnance Survey maps of the UK (for an example of what they look like, see http://binged.it/PETY5J).

```
var map = L.map('map', {
            center: [57.2467971193, -6.21054885184], 
            zoom: 13}
            );
var bing = new L.BingLayer("<API_KEY>", {type: 'OrdnanceSurvey', attribution: 'Ordnance Survey maps using Bing maps API'}).addTo(map);
```

I was getting a TypeError on line 66 of Bing.js

```
Uncaught TypeError: Cannot read property 'length' of null 
```

This seems to be because the bing api is returning "imageryProviders":null when the map type is OrdnanceSurvey.

My patch is pretty simple, it adds an if statement to checks imageryProviders before updating the attribution.

Hopefully somebody else will find this useful. Thank you for your work creating the Bing plugin for leaflet.

cheers,
Alasdair
