### PR TITLE
Max Zoom of layer on map type change

### DIFF
--- a/layer/tile/Google.js
+++ b/layer/tile/Google.js
@@ -142,6 +142,9 @@ L.Google = L.Class.extend({
 
 		this._google.setCenter(_center);
 		this._google.setZoom(this._map.getZoom());
+		if (this._google.getZoom() != this._map.getZoom()) {
+			this._map.setZoom(this._google.getZoom());
+		}
 		//this._google.fitBounds(google_bounds);
 	},
 


### PR DESCRIPTION
This little fix prevents that the google terrain map is out of synch with the overlays if the leaflet zoom level is too high.

The check only works when you switch to the terrain layer. It would be nice to find a way to prevent the user to zoom too far on the terrain layer too.
