### PR TITLE
Add support for relative icon paths

### DIFF
--- a/layer/vector/KML.js
+++ b/layer/vector/KML.js
@@ -334,16 +334,18 @@ L.KMLIcon = L.Icon.extend({
 		img.onload = function () {
 			var i = new Image();
 			i.src = this.src;
-			this.style.width = i.width + 'px';
-			this.style.height = i.height + 'px';
+			if((i.width > 0) && (i.height > 0)) {
+				this.style.width = i.width + 'px';
+				this.style.height = i.height + 'px';
 
-			if (this.anchorType.x === 'UNITS_FRACTION' || this.anchorType.x === 'fraction') {
-				img.style.marginLeft = (-this.anchor.x * i.width) + 'px';
+				if (this.anchorType.x === 'UNITS_FRACTION' || this.anchorType.x === 'fraction') {
+					img.style.marginLeft = (-this.anchor.x * i.width) + 'px';
+				}
+				if (this.anchorType.y === 'UNITS_FRACTION' || this.anchorType.x === 'fraction') {
+					img.style.marginTop  = (-(1 - this.anchor.y) * i.height) + 'px';
+				}
+				this.style.display = "";
 			}
-			if (this.anchorType.y === 'UNITS_FRACTION' || this.anchorType.x === 'fraction') {
-				img.style.marginTop  = (-(1 - this.anchor.y) * i.height) + 'px';
-			}
-			this.style.display = "";
 		};
 		return img;
 	},


### PR DESCRIPTION
This change adds support for relative icons in KML files.

Note: because the parser functions are not members of the KML layer class, I had to find a way to pass state through the parser.  To do this I added a 'state' parameter that stores the information.  This could be done in other ways, just not sure what the preferred one is for this class.
