### PR TITLE
Added support of HTTPS protocol for Bing layers

### DIFF
--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -50,7 +50,8 @@ L.BingLayer = L.TileLayer.extend({
 			}
 			_this.initMetadata();
 		};
-		var url = "http://dev.virtualearth.net/REST/v1/Imagery/Metadata/" + this.options.type + "?include=ImageryProviders&jsonp=" + cbid + "&key=" + this._key;
+		var url = window.location.protocol+"//dev.virtualearth.net/REST/v1/Imagery/Metadata/"
+					+ this.options.type + "?include=ImageryProviders&jsonp=" + cbid + "&key=" + this._key;
 		var script = document.createElement("script");
 		script.type = "text/javascript";
 		script.src = url;


### PR DESCRIPTION
I have page where I use Bing plugin for Leaflet and it's served by HTTPS. There was a problem on Chrome which don't allow mixed (https and http) content on page and prevents loading maps (other browsers sometimes displays warning in this case).

I added fix to this – URL of Bing maps will be determined by `window.location.protocol` and this solves problem.
