### PR TITLE
Fixed Permalink: repeated params whith useAnchor=false 

### DIFF
--- a/control/Permalink.js
+++ b/control/Permalink.js
@@ -138,7 +138,7 @@ L.UrlUtil = {
 		for(var i = 0; i < params.length; i++) {
 			var tmp = params[i].split('=');
 			if (tmp.length != 2) continue;
-			p[tmp[0]] = tmp[1];
+			p[tmp[0]] = decodeURI(tmp[1]);
 		}
 		return p;
 	},


### PR DESCRIPTION
Permalink with useAnchor=false uses ? instead of # as delimiter between
base URL and parameters. But the parameters are added twice ore more if
Permalink is clicked again.
Fixes #55
Fixes #73
