### PR TITLE
Проверка на существование console

### DIFF
--- a/layer/tile/Yandex.js
+++ b/layer/tile/Yandex.js
@@ -104,7 +104,7 @@ L.Yandex = L.Class.extend({
 		// If traffic layer is requested check if control.TrafficControl is ready
 		if (this.options.traffic)
 			if (ymaps.control === undefined ||
-			    ymaps.control.TrafficControl === undefined) {
+					ymaps.control.TrafficControl === undefined) {
 				if (console) {
 					console.debug("L.Yandex: loading traffic and controls");
 				}
@@ -121,7 +121,7 @@ L.Yandex = L.Class.extend({
 			this._type = new ymaps.MapType("null", []);
 			map.container.getElement().style.background = "transparent";
 		}
-		map.setType(this._type)
+		map.setType(this._type);
 
 		this._yandex = map;
 		this._update(true);
@@ -151,7 +151,7 @@ L.Yandex = L.Class.extend({
 	_resize: function(force) {
 		var size = this._map.getSize(), style = this._container.style;
 		if (style.width == size.x + "px" &&
-		    style.height == size.y + "px")
+				style.height == size.y + "px")
 			if (force != true) return;
 		this.setElementSize(this._container, size);
 		var b = this._map.getBounds(), sw = b.getSouthWest(), ne = b.getNorthEast();


### PR DESCRIPTION
Привет.
На тайлах Ядекс.карт есть вызов console.debug, а проверки на существование console нет. Это может вызывать js-ошибку, например, в IE.
Также я в паре мест заменил пробелы на табы и добавил забытую точку с запятой (jshint подсветил).
