### PR TITLE
npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "author": "Pavel Shramov",
   "name": "leaflet-plugins",
-  "version": "0.0.2",
+  "version": "1.0.1",
   "description": "Miscellaneous plugins for Leaflet library for services that need to display route information and need satellite imagery from different providers",
   "repository": {
     "type": "git",
     "url": "git@github.com:shramov/leaflet-plugins.git"
   },
   "contributors": [
+    "Bruno Bergot <bruno@eliaz.fr>",
     "Andrey Lushchick <andrew@lushchick.org>"
   ],
   "keywords": [


### PR DESCRIPTION
Hello.

I've published leaflet-plugins to npm: https://npmjs.org/package/leaflet-plugins
Now package pulls code from my forked repo, because I could not publish it by linking to your repo as there was no package.json.
This pull request adds package.json and changes the repo to be git@github.com:shramov/leaflet-plugins.git

After this pull request is merged, i could add someone to package owners list, so you'll be able to publish it as well.

Npm is a great package manager and I believe many people will be happy to have these wonderful plugins in the registry.
- Thanks,

Andrey
