### PR TITLE
Broken onRemove function

### DIFF
--- a/control/Scale.js
+++ b/control/Scale.js
@@ -35,9 +35,7 @@ L.Control.Scale = L.Control.extend({
 	},
 
 	onRemove: function(map) {
-		map._container.removeChild(this._label);
-		map._container.removeChild(this._canvas);
-		map.off('zoomend', this._reset);
+		map.off('zoomend', this._update, this);
 	},
 
 	getPosition: function() {


### PR DESCRIPTION
Removing children causes error, because parent has already been removed. In addition, turning off the event handler for "zoomend" didn't match where it was turned on.
