### PR TITLE
Fix non integer zoom request when using pinch zoom

### DIFF
--- a/layer/tile/Google.js
+++ b/layer/tile/Google.js
@@ -175,7 +175,7 @@ L.Google = L.Class.extend({
 		var _center = new google.maps.LatLng(center.lat, center.lng);
 
 		this._google.setCenter(_center);
-		this._google.setZoom(e.zoom);
+		this._google.setZoom(Math.round(e.zoom));
 	},
 
 


### PR DESCRIPTION
Pinch zooming on mobile phones generates invalid non integer zoom levels. The Google server reports error 404 and the tiles disappear during zoom. Rounding the zoom level fixes this issue.

Similar problem to this: https://github.com/Leaflet/Leaflet/issues/1934
