### PR TITLE
fixes Google exception when zooming to non-whole numbers.

### DIFF
--- a/layer/tile/Google.js
+++ b/layer/tile/Google.js
@@ -154,7 +154,7 @@ L.Google = L.Class.extend({
 		var _center = new google.maps.LatLng(center.lat, center.lng);
 
 		this._google.setCenter(_center);
-		this._google.setZoom(this._map.getZoom());
+		this._google.setZoom(Math.round(this._map.getZoom()));
 
 		this._checkZoomLevels();
 	},


### PR DESCRIPTION
Issue evident during touch zoom on touch devices. `this._map.getZoom()` will return values with decimals (like 14.111888250817666) triggering HTTP 400 from Google.
