### PR TITLE
! Catch and ignore error for old IE

### DIFF
--- a/layer/tile/Google.js
+++ b/layer/tile/Google.js
@@ -90,7 +90,12 @@ L.Google = L.Class.extend({
 		if (!this._container) {
 			this._container = L.DomUtil.create('div', 'leaflet-google-layer leaflet-top leaflet-left');
 			this._container.id = '_GMapContainer_' + L.Util.stamp(this);
-			this._container.style.zIndex = 'auto';
+			try {
+				this._container.style.zIndex = 'auto';
+			}
+			catch(ex) {
+				// Assumed to be type mismatch error and ignore it
+			}
 		}
 
 		tilePane.insertBefore(this._container, first);


### PR DESCRIPTION
I am testing this on IE7, and found out that setting z-index to 'auto' with JS will throw error
This is not the best fix but it has least change

A better fix would be using CSS
But I am not sure where the file should be created etc.

About setting z-index on IE7:
http://bugs.jquery.com/ticket/6525


Edit: that z-index is necessary for a fix
https://github.com/shramov/leaflet-plugins/commit/b4d8e70952ea00f09a412ef957d83b2193b7a062

