### PR TITLE
L.BingLayer: URIs like "file:///" now supported

### DIFF
--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -49,8 +49,11 @@ L.BingLayer = L.TileLayer.extend({
 			}
 			_this.initMetadata();
 		};
-		var url = document.location.protocol + '//dev.virtualearth.net/REST/v1/Imagery/Metadata/' + this.options.type + '?include=ImageryProviders&jsonp=' + cbid +
-		          '&key=' + this._key + '&UriScheme=' + document.location.protocol.slice(0, -1);
+
+		var urlScheme = (document.location.protocol.indexOf('http') == 0)? document.location.protocol.slice(0, -1) : 'http'
+		var url = urlScheme + '://dev.virtualearth.net/REST/v1/Imagery/Metadata/' + this.options.type + '?include=ImageryProviders&jsonp=' + cbid +
+		          '&key=' + this._key + '&UriScheme=' + urlScheme;
+
 		var script = document.createElement('script');
 		script.type = 'text/javascript';
 		script.src = url;


### PR DESCRIPTION
Enhanced the url-scheme detection used when building up URIs for requests to the Bing REST API - it now defaults to 'http' when unusual schemes are encountered. This allows L.BingLayer to be used by developers performing experiments in html files that aren't hosted over HTTP.