### PR TITLE
Update KML.js so that CORS works on IE8 and IE9

### DIFF
--- a/layer/vector/KML.js
+++ b/layer/vector/KML.js
@@ -17,7 +17,14 @@ L.KML = L.FeatureGroup.extend({
 		if (async === undefined) async = this.options.async;
 		if (options === undefined) options = this.options;
 
-		var req = new window.XMLHttpRequest();
+		var req = new window.XMLHttpRequest
+		
+		
+        	//Check for IE8 and IE9 Fix Cors for those browsers
+		if (req.withCredentials === undefined) {
+		    req = new XDomainRequest();
+		}
+		
 		req.open('GET', url, async);
 		try {
 			req.overrideMimeType('text/xml'); // unsupported by IE


### PR DESCRIPTION
IE8 and IE9 support CORS, but they do it with the XDomainRequest object