### PR TITLE
fixed parameter types to strings

### DIFF
--- a/control/Permalink.js
+++ b/control/Permalink.js
@@ -47,7 +47,7 @@ L.Control.Permalink = L.Control.extend({
 		if (!this._map) return;
 
 		var center = this._round_point(this._map.getCenter());
-		this._update({zoom: this._map.getZoom(), lat: center.lat, lon: center.lng});
+		this._update({zoom: String(this._map.getZoom()), lat: String(center.lat), lon: String(center.lng)});
 	},
 
 	_update_href: function() {


### PR DESCRIPTION
Hi

I believe there is a bug in Permalink.js. It becomes apparent when you enable "useAnchor" and "useLocation". The code continues to trigger calls to the `_set_urlvars` function. The reason is that

```
        if (eq(p, this._params) && eq(this._params, p))
            return;
```
is never true. This happens because the types of zoom, lat and lon in the two dicts are not the same types. They are strings in one of them and floats in the other.

Best regards,
Jesper
