### PR TITLE
Add AMP/CommonJS wrapper for tiles

### DIFF
--- a/layer/index.js
+++ b/layer/index.js
@@ -1,0 +1,7 @@
+module.export = {
+  tile: {
+    Bing: require('./tile/Bing'),
+    Google: require('./tile/Google'),
+    Yandex: require('./tile/Yandex'),
+  }
+}

--- a/layer/index.js
+++ b/layer/index.js
@@ -1,4 +1,4 @@
-module.export = {
+module.exports = {
   tile: {
     Bing: require('./tile/Bing'),
     Google: require('./tile/Google'),

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -1,3 +1,19 @@
+(function(factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['leaflet'], factory);
+	} else if (typeof module !== 'undefined') {
+		// Node/CommonJS
+		module.exports = factory(require('leaflet'));
+	} else {
+		// Browser globals
+		if (typeof this.L === 'undefined')
+			throw 'Leaflet must be loaded first!';
+		factory(this.L);
+	}
+}(function(L) {
+
+
 L.BingLayer = L.TileLayer.extend({
 	options: {
 		subdomains: [0, 1, 2, 3],
@@ -123,3 +139,8 @@ L.BingLayer = L.TileLayer.extend({
 L.bingLayer = function (key, options) {
     return new L.BingLayer(key, options);
 };
+
+
+return L.BingLayer;
+
+}));

--- a/layer/tile/Google.js
+++ b/layer/tile/Google.js
@@ -4,6 +4,21 @@
 
 /* global google: true */
 
+(function(factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['leaflet'], factory);
+	} else if (typeof module !== 'undefined') {
+		// Node/CommonJS
+		module.exports = factory(require('leaflet'));
+	} else {
+		// Browser globals
+		if (typeof this.L === 'undefined')
+			throw 'Leaflet must be loaded first!';
+		factory(this.L);
+	}
+}(function(L) {
+
 L.Google = L.Class.extend({
 	includes: L.Mixin.Events,
 
@@ -199,3 +214,9 @@ L.Google.asyncInitialize = function() {
 	}
 	L.Google.asyncWait = [];
 };
+
+
+return L.Google;
+
+}));
+

--- a/layer/tile/Yandex.js
+++ b/layer/tile/Yandex.js
@@ -4,6 +4,21 @@
 
 /* global ymaps: true */
 
+(function(factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['leaflet'], factory);
+	} else if (typeof module !== 'undefined') {
+		// Node/CommonJS
+		module.exports = factory(require('leaflet'));
+	} else {
+		// Browser globals
+		if (typeof this.L === 'undefined')
+			throw 'Leaflet must be loaded first!';
+		factory(this.L);
+	}
+}(function(L) {
+
 L.Yandex = L.Class.extend({
 	includes: L.Mixin.Events,
 
@@ -181,3 +196,8 @@ L.Yandex = L.Class.extend({
 		this._yandex.container.fitToViewport();
 	}
 });
+
+
+return L.Yandex;
+
+}));

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "author": "Pavel Shramov",
   "name": "leaflet-plugins",
   "version": "1.3.9",
+  "main": "layer/index.js",
   "description": "Miscellaneous plugins for Leaflet library for services that need to display route information and need satellite imagery from different providers",
   "license": "MIT",
   "repository": {
@@ -26,5 +27,8 @@
     "yandex",
     "kml",
     "gpx"
-  ]
+  ],
+  "dependencies": {
+    "leaflet": "^0.7.3"
+  }
 }


### PR DESCRIPTION
When we want to use these plugins with browserify or webpack, it would be easier with this wrapping.
See https://github.com/umdjs/umd