### PR TITLE
Allow to switch out of Bing layer even if Bing API broken

### DIFF
--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -11,6 +11,7 @@ L.BingLayer = L.TileLayer.extend({
 
 		this._key = key;
 		this._url = null;
+		this._providers = [];
 		this.metaRequested = false;
 	},
 
@@ -64,7 +65,6 @@ L.BingLayer = L.TileLayer.extend({
 		var r = meta.resourceSets[0].resources[0];
 		this.options.subdomains = r.imageUrlSubdomains;
 		this._url = r.imageUrl;
-		this._providers = [];
 		if (r.imageryProviders) {
 			for (var i = 0; i < r.imageryProviders.length; i++) {
 				var p = r.imageryProviders[i];


### PR DESCRIPTION
Right now, bing somehow broken and initMetadata() call newer executed.

This cause error when end user tries to change the layer in onRemove()

`Cannot read property length of underfined` when iterating over `this._providers.length`