### PR TITLE
anchor-based permalink should not erase the query string

### DIFF
--- a/control/Permalink.js
+++ b/control/Permalink.js
@@ -94,13 +94,14 @@ L.Control.Permalink = L.Control.extend({
 
 	_set_urlvars: function()
 	{
-		this._url_base = window.location.href.split('#')[0].split('?')[0];
-
 		var p;
-		if (this.options.useAnchor)
+		if (this.options.useAnchor) {
 			p = L.UrlUtil.queryParse(L.UrlUtil.hash());
-		else
+			this._url_base = window.location.href.split('#')[0];
+		} else {
 			p = L.UrlUtil.queryParse(L.UrlUtil.query());
+			this._url_base = window.location.href.split('#')[0].split('?')[0];
+		}
 		
 		function eq(x, y) {
 			for(var i in x)


### PR DESCRIPTION
Problem: When using an address with a query string and a Permalink
with useAnchor=true, the href of the Permalink does not contain the
query string of the current location.

This behavior is correct when the Permalink has useAnchor=false. See
commit 9d708a24938d778ffb2e3d445b4804e6e9056c55.