### PR TITLE
The sensor parameter is no longer required.

### DIFF
--- a/examples/deferred.html
+++ b/examples/deferred.html
@@ -19,7 +19,7 @@ var layerdefs = {
 		init: function() {return new L.TileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');}},
 	kosmo: { name: "Космоснимки", js: [],
 		init: function() {return new L.TileLayer('http://{s}.tile.osmosnimki.ru/kosmo/{z}/{x}/{y}.png', {attribution:'Tiles Courtesy of <a href="http://kosmosnimki.ru/" target="_blank">kosmosnimki.ru</a>'});}},
-	gsat: { name: "Google", js: ["../layer/tile/Google.js", "http://maps.google.com/maps/api/js?v=3&sensor=false&callback=L.Google.asyncInitialize"],
+	gsat: { name: "Google", js: ["../layer/tile/Google.js", "http://maps.google.com/maps/api/js?v=3&callback=L.Google.asyncInitialize"],
 		init: function() {return new L.Google(); }},
 	ysat: { name: "Yandex", js: ["../layer/tile/Yandex.js", "http://api-maps.yandex.ru/2.0/?load=package.map&lang=ru-RU"],
 		init: function() {return new L.Yandex("satellite"); }},

--- a/examples/google-custom.html
+++ b/examples/google-custom.html
@@ -3,7 +3,7 @@
 	<title>Google Custom Styles // Leaflet</title>
 	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
 	<script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
-	<script src="http://maps.google.com/maps/api/js?v=3&sensor=false"></script>
+	<script src="http://maps.google.com/maps/api/js?v=3"></script>
 	<script src="../layer/tile/Google.js"></script>
 </head>
 <body>

--- a/examples/google.html
+++ b/examples/google.html
@@ -3,7 +3,7 @@
 	<title>Google // Leaflet</title>
 	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
 	<script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
-	<script src="http://maps.google.com/maps/api/js?v=3&sensor=false"></script>
+	<script src="http://maps.google.com/maps/api/js?v=3"></script>
 	<script src="../layer/tile/Google.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Hey guys, I came across this today. Google no longer recommends sending the `sensor` parameter. Not a big deal, but here's a PR to remove it.

See also: https://developers.google.com/maps/documentation/javascript/error-messages