### PR TITLE
request KML explicitly in Accept: header

### DIFF
--- a/layer/vector/KML.js
+++ b/layer/vector/KML.js
@@ -36,6 +36,8 @@ L.KML = L.FeatureGroup.extend({
 			setTimeout(function () { xdr.send(); }, 0);
 		} else {
 			req.open('GET', url, async);
+			req.setRequestHeader("Accept",
+					"application/vnd.google-earth.kml+xml");
 			try {
 				req.overrideMimeType('text/xml'); // unsupported by IE
 			} catch (e) { }


### PR DESCRIPTION
Some web services might serve geographical data in multiple formats.  In these cases, it is good to explicitly request KML from the server with content negotiation.