### PR TITLE
Marker Rotation over shortest angle

### DIFF
--- a/layer/Marker.Rotate.js
+++ b/layer/Marker.Rotate.js
@@ -26,7 +26,7 @@
 
 		setIconAngle: function (iconAngle) {
 			// find shortest angle to turn over
-			this.options.iconAngle = getShortestEndDegree(this.options.iconAngle, iconAngle);
+			this.options.iconAngle = this._getShortestEndDegree(this.options.iconAngle, iconAngle);
 			if (this._map)
 				this.update();
 		},

--- a/layer/Marker.Rotate.js
+++ b/layer/Marker.Rotate.js
@@ -15,9 +15,18 @@
 			transform += ' translate(' + a.x + 'px, ' + a.y + 'px)';
 			i.style[L.DomUtil.TRANSFORM] += transform;
 		},
+		
+		_getShortestEndDegree: function(startDegrees, endDegrees) {
+			var turnAngle = Math.abs(endDegrees - startDegrees);
+			var turnAnglePositive = (endDegrees - startDegrees) >= 0;
+			if (turnAngle <= 180) return endDegrees;
+			var result = startDegrees + (360 - turnAngle) * (turnAnglePositive ? -1 : 1);
+			return result;
+		},
 
 		setIconAngle: function (iconAngle) {
-			this.options.iconAngle = iconAngle;
+			// find shortest angle to turn over
+			this.options.iconAngle = getShortestEndDegree(this.options.iconAngle, iconAngle);
 			if (this._map)
 				this.update();
 		},


### PR DESCRIPTION
I added a function that calculates the shortest angle between the current marker angle and the new - to be set - marker angle.

This is especially interesting and necessary if the marker movements are animated, e.g. with the following CSS transition:

```css
<style>
    /* Animates marker movements */
    .leaflet-marker-pane > * {
        -webkit-transition: transform 1.0s linear;
        -moz-transition: transform 1.0s linear;
        -o-transition: transform 1.0s linear;
        -ms-transition: transform 1.0s linear;
        transition: transform 1.0s linear;
    }
</style>
```

Without the shortest angle calculation, the animation would always turn clockwise, even though an angle change from 10° to 340° is shorter to turn counter clockwise.

For non-animated marker movements, there won't be any noticeable difference in rotation.

 **Credits** for the shortest-angle function: [stefbw](https://github.com/stefbw)