### PR TITLE
Set iconAngle default

### DIFF
--- a/layer/Marker.Rotate.js
+++ b/layer/Marker.Rotate.js
@@ -26,7 +26,7 @@
 
 		setIconAngle: function (iconAngle) {
 			// find shortest angle to turn over
-			this.options.iconAngle = this._getShortestEndDegree(this.options.iconAngle, iconAngle);
+			this.options.iconAngle = this._getShortestEndDegree(this.options.iconAngle || 0, iconAngle);
 			if (this._map)
 				this.update();
 		},


### PR DESCRIPTION
In case the this.options.iconAngle is not set yet (initial case) the starting angle should be 0.
Otherwise the return of _getShortestEndDegree is always `NaN` and the marker does not turn anymore.