### PR TITLE
Handle link tag

### DIFF
--- a/layer/vector/GPX.js
+++ b/layer/vector/GPX.js
@@ -103,7 +103,7 @@ L.GPX = L.FeatureGroup.extend({
 		}
 		el = xml.getElementsByTagName('link');
 		if (el.length)
-			link = el[0].getAttribute('href')
+			link = el[0].getAttribute('href');
 
 		if (layer instanceof L.Path)
 			len = this._polylineLen(layer);

--- a/layer/vector/GPX.js
+++ b/layer/vector/GPX.js
@@ -103,7 +103,7 @@ L.GPX = L.FeatureGroup.extend({
 		}
 		el = xml.getElementsByTagName('link');
 		if (el.length)
-			link = el[0].childNodes[0].nodeValue;
+			link = el[0].getAttribute('href')
 
 		if (layer instanceof L.Path)
 			len = this._polylineLen(layer);

--- a/layer/vector/GPX.js
+++ b/layer/vector/GPX.js
@@ -92,7 +92,7 @@ L.GPX = L.FeatureGroup.extend({
 	},
 
 	parse_name: function (xml, layer) {
-		var i, el, txt='', name, descr='', len=0;
+		var i, el, txt='', name, descr='', link, len=0;
 		el = xml.getElementsByTagName('name');
 		if (el.length)
 			name = el[0].childNodes[0].nodeValue;
@@ -101,12 +101,16 @@ L.GPX = L.FeatureGroup.extend({
 			for (var j = 0; j < el[i].childNodes.length; j++)
 				descr = descr + el[i].childNodes[j].nodeValue;
 		}
+		el = xml.getElementsByTagName('link');
+		if (el.length)
+			link = el[0].childNodes[0].nodeValue;
 
 		if (layer instanceof L.Path)
 			len = this._polylineLen(layer);
 
 		if (name) txt += '<h2>' + name + '</h2>' + descr;
 		if (len) txt += '<p>' + this._humanLen(len) + '</p>';
+		if (link) txt += '<p><a target="_blank" href="'+link+'">[...]</a></p>'; 
 
 		if (layer && layer._popup === undefined) layer.bindPopup(txt);
 		return txt;


### PR DESCRIPTION
proposed change for issue #235 

the following gpx-fragment will be rendered to the plugin, showed by the given part of the screen shot, and the [...] link the further information source in wikipedia.de:
```
 <wpt lat="51.48719884" lon="7.646843791">
    <ele>184.00000</ele>
    <name>Station 1</name>
    <desc>Barocke Südansicht von Haus Opherdicke, noch ist die unverbaute Symmetrie zu bewundern.</desc>
    <link href="https://de.wikipedia.org/wiki/Haus%20Opherdicke" />
    <sym>sightseeing</sym>
    <type>Sightseeing</type>
  </wpt>
```
![linkexample](https://cloud.githubusercontent.com/assets/20812580/17362949/f3ff2ce0-5977-11e6-85ca-d066f418af8f.png)
