### PR TITLE
Fix decoding URI-encoded permalink parameters

### DIFF
--- a/control/Permalink.js
+++ b/control/Permalink.js
@@ -148,7 +148,7 @@ L.UrlUtil = {
 		for (var i = 0; i < params.length; i++) {
 			var tmp = params[i].split('=');
 			if (tmp.length !== 2) continue;
-			p[tmp[0]] = decodeURI(tmp[1]);
+			p[tmp[0]] = decodeURIComponent(tmp[1]);
 		}
 		return p;
 	},

--- a/control/test/PermalinkTest.js
+++ b/control/test/PermalinkTest.js
@@ -1,0 +1,34 @@
+'use strict'
+var test = require('tap').test;
+var fs = require('fs');
+
+// Hackish
+GLOBAL.L = {
+  Control: {
+    extend: function () {}
+  },
+  Mixin: {
+    Events: null
+  }
+}
+eval(fs.readFileSync('control/Permalink.js').toString());
+
+
+test('L.UrlUtil.queryParse', function (t) {
+  var data = [
+    ['a=1&b=2',     {'a': '1', 'b': '2'}],
+    ['a=1&amp;b=2', {'a': '1', 'b': '2'}],
+    ['a=1,2',       {'a': '1,2'}],
+    ['a=1%2C2',     {'a': '1,2'}],
+    ['a=1%2C2&b=3%7C4', {'a': '1,2', 'b': '3|4'}],
+    ['name=Лилль',  {'name': 'Лилль'}],
+    ['name=%D0%9B%D0%B8%D0%BB%D0%BB%D1%8C',  {'name': 'Лилль'}],
+    ['a=1&name=%D0%9B%D0%B8%D0%BB%D0%BB%D1%8C', {'a': '1', 'name': 'Лилль'}],
+  ];
+  data.forEach(function (d) {
+    t.strictSame(L.UrlUtil.queryParse(d[0]), d[1], 'Parsing '+d[0]);
+  });
+  t.plan(data.length, 'Check all parsing tests were done');
+  t.done();
+})
+

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "url": "git@github.com:shramov/leaflet-plugins.git"
   },
   "scripts": {
-    "test": "eslint --config .eslintrc control/* layer/*"
+    "test": "tap control/test/*.js && eslint --config .eslintrc control/* layer/*"
   },
   "devDependencies": {
-    "eslint": "2.3.0"
+    "eslint": "2.3.0",
+    "tap": "^6.3.2"
   },
   "contributors": [
     "Bruno Bergot <bruno@eliaz.fr>"


### PR DESCRIPTION
decodeURI() only decodes characters that are encoded by encodeURI(), as
a consequence character such as comas were not decoded in permalink
parameters.

issue #237