### PR TITLE
L.BingLayer: fixes / updates / refactoring

### DIFF
--- a/examples/bing.html
+++ b/examples/bing.html
@@ -15,12 +15,20 @@
 		zoom: 10
 	});
 	var apiKey = '[YOUR_BING_MAPS_KEY]';
-	var imagerySet = 'RoadOnDemand';
+
+	// https://docs.microsoft.com/en-us/bingmaps/articles/custom-map-styles-in-bing-maps#midnight-commander-style
+	var styleMidnightCommander = 'me|lbc:ffffff;loc:000000_pl|bsc:144b53;boc:00000000_pt|ic:0c4152;fc:000000;sc:0c4152_trs|sc:000000;fc:000000_hg|sc:158399;fc:000000_cah|sc:158399;fc:000000_ard|sc:157399;fc:000000_mr|sc:157399;fc:000000_rl|sc:146474;fc:000000_str|fc:115166_wt|fc:021019_ar|fc:115166_g|lc:0b334d';
 	var baseLayers = {
-		Bing: L.bingLayer(apiKey, {
-			culture: 'ru',
-			type: imagerySet
+		'Bing': L.bingLayer(apiKey, {
+			// type: 'RoadOnDemand' // default
 		}).addTo(map),
+		'Bing (styled)': L.bingLayer(apiKey, {
+			style: styleMidnightCommander
+		}),
+		'Bing Aerial (ru)': L.bingLayer(apiKey, {
+			culture: 'ru',
+			type: 'AerialWithLabelsOnDemand'
+		}),
 		OSM: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')
 	};
 	L.control.layers(baseLayers).addTo(map);

--- a/examples/bing.html
+++ b/examples/bing.html
@@ -20,12 +20,15 @@
 	var styleMidnightCommander = 'me|lbc:ffffff;loc:000000_pl|bsc:144b53;boc:00000000_pt|ic:0c4152;fc:000000;sc:0c4152_trs|sc:000000;fc:000000_hg|sc:158399;fc:000000_cah|sc:158399;fc:000000_ard|sc:157399;fc:000000_mr|sc:157399;fc:000000_rl|sc:146474;fc:000000_str|fc:115166_wt|fc:021019_ar|fc:115166_g|lc:0b334d';
 	var baseLayers = {
 		'Bing': L.bingLayer(apiKey, {
+			detectRetina: true,
 			// type: 'RoadOnDemand' // default
 		}).addTo(map),
 		'Bing (styled)': L.bingLayer(apiKey, {
+			detectRetina: true,
 			style: styleMidnightCommander
 		}),
 		'Bing Aerial (ru)': L.bingLayer(apiKey, {
+			detectRetina: true,
 			culture: 'ru',
 			type: 'AerialWithLabelsOnDemand'
 		}),

--- a/examples/bing.html
+++ b/examples/bing.html
@@ -1,23 +1,30 @@
 <html>
-  <head>
-  	<title>Leaflet</title>
-	<link rel="stylesheet" href="http://unpkg.com/leaflet@1.3.1/dist/leaflet.css" />
-	<script src="http://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
-  	<script src="../layer/tile/Bing.js"></script>
-  </head>
-  <body>
-  	<div style="width:100%; height:100%" id="map"></div>
-      <script type='text/javascript'>
-        var map = new L.Map('map', {center: new L.LatLng(67.6755, 33.936), zoom: 10 });
-        var osm = new L.TileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+<head>
+	<title>Leaflet</title>
+	<link rel="stylesheet" href="http://unpkg.com/leaflet@1.5.1/dist/leaflet.css" />
+	<script src="http://unpkg.com/leaflet@1.5.1/dist/leaflet.js"></script>
+	<script src="../layer/tile/Bing.js"></script>
+</head>
+<body>
 
-        // for all possible values and explanations see "Template Parameters" in https://msdn.microsoft.com/en-us/library/ff701716.aspx
-        var imagerySet = "Aerial"; // AerialWithLabels | Birdseye | BirdseyeWithLabels | Road
+<div style="width:100%; height:100%" id="map"></div>
 
-        var bing = new L.BingLayer("YOUR_API_KEY", {type: imagerySet});
+<script type='text/javascript'>
+	var map = L.map('map', {
+		center: [67.6755, 33.936],
+		zoom: 10
+	});
+	var apiKey = '[YOUR_BING_MAPS_KEY]';
+	var imagerySet = 'RoadOnDemand';
+	var baseLayers = {
+		Bing: L.bingLayer(apiKey, {
+			culture: 'ru',
+			type: imagerySet
+		}).addTo(map),
+		OSM: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')
+	};
+	L.control.layers(baseLayers).addTo(map);
+ </script>
 
-        map.addLayer(bing);
-        map.addControl(new L.Control.Layers({'OSM':osm, "Bing":bing}, {}));
-      </script>
-  </body>
+</body>
 </html>

--- a/examples/bing.html
+++ b/examples/bing.html
@@ -24,24 +24,24 @@
 	[	'Aerial', 'AerialWithLabelsOnDemand',
 		'RoadOnDemand',
 		'CanvasDark', 'CanvasLight', 'CanvasGray'
-	].forEach(function (type) {
-		baseLayers[type] = L.bingLayer(L.extend({type: type}, defaults));
+	].forEach(function (imagerySet) {
+		baseLayers[imagerySet] = L.bingLayer(L.extend({imagerySet: imagerySet}, defaults));
 	});
 
 	// https://docs.microsoft.com/en-us/bingmaps/articles/custom-map-styles-in-bing-maps#midnight-commander-style
 	var styleMidnightCommander = 'me|lbc:ffffff;loc:000000_pl|bsc:144b53;boc:00000000_pt|ic:0c4152;fc:000000;sc:0c4152_trs|sc:000000;fc:000000_hg|sc:158399;fc:000000_cah|sc:158399;fc:000000_ard|sc:157399;fc:000000_mr|sc:157399;fc:000000_rl|sc:146474;fc:000000_str|fc:115166_wt|fc:021019_ar|fc:115166_g|lc:0b334d';
 	baseLayers['Custom style + "ru" culture'] = L.bingLayer(L.extend({}, defaults, {
-		type: 'RoadOnDemand',
+		imagerySet: 'RoadOnDemand',
 		style: styleMidnightCommander,
 		culture: 'ru'
 	}));
 
 	baseLayers['[deprecated] Road'] = L.bingLayer(L.extend({}, defaults, {
-		type: 'Road',
+		imagerySet: 'Road',
 		retinaDpi: false
 	}));
 	baseLayers['[deprecated] AerialWithLabels'] = L.bingLayer(L.extend({}, defaults, {
-		type: 'AerialWithLabels',
+		imagerySet: 'AerialWithLabels',
 		retinaDpi: false
 	}));
 

--- a/examples/bing.html
+++ b/examples/bing.html
@@ -16,25 +16,38 @@
 	});
 	var apiKey = '[YOUR_BING_MAPS_KEY]';
 
+	var defaults = {
+		key: apiKey,
+		detectRetina: true
+	};
+	var baseLayers = {};
+	[	'Aerial', 'AerialWithLabelsOnDemand',
+		'RoadOnDemand',
+		'CanvasDark', 'CanvasLight', 'CanvasGray'
+	].forEach(function (type) {
+		baseLayers[type] = L.bingLayer(L.extend({type: type}, defaults));
+	});
+
 	// https://docs.microsoft.com/en-us/bingmaps/articles/custom-map-styles-in-bing-maps#midnight-commander-style
 	var styleMidnightCommander = 'me|lbc:ffffff;loc:000000_pl|bsc:144b53;boc:00000000_pt|ic:0c4152;fc:000000;sc:0c4152_trs|sc:000000;fc:000000_hg|sc:158399;fc:000000_cah|sc:158399;fc:000000_ard|sc:157399;fc:000000_mr|sc:157399;fc:000000_rl|sc:146474;fc:000000_str|fc:115166_wt|fc:021019_ar|fc:115166_g|lc:0b334d';
-	var baseLayers = {
-		'Bing': L.bingLayer(apiKey, {
-			detectRetina: true,
-			// type: 'RoadOnDemand' // default
-		}).addTo(map),
-		'Bing (styled)': L.bingLayer(apiKey, {
-			detectRetina: true,
-			style: styleMidnightCommander
-		}),
-		'Bing Aerial (ru)': L.bingLayer(apiKey, {
-			detectRetina: true,
-			culture: 'ru',
-			type: 'AerialWithLabelsOnDemand'
-		}),
-		OSM: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')
-	};
+	baseLayers['Custom style + "ru" culture'] = L.bingLayer(L.extend({}, defaults, {
+		type: 'RoadOnDemand',
+		style: styleMidnightCommander,
+		culture: 'ru'
+	}));
+
+	baseLayers['[deprecated] Road'] = L.bingLayer(L.extend({}, defaults, {
+		type: 'Road',
+		retinaDpi: false
+	}));
+	baseLayers['[deprecated] AerialWithLabels'] = L.bingLayer(L.extend({}, defaults, {
+		type: 'AerialWithLabels',
+		retinaDpi: false
+	}));
+
+	baseLayers['RoadOnDemand'].addTo(map);
 	L.control.layers(baseLayers).addTo(map);
+	map.locate({ setView: true, maxZoom: 14 });
  </script>
 
 </body>

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -23,10 +23,14 @@ L.BingLayer = L.TileLayer.extend({
 
 		attribution: 'Bing',
 		minZoom: 1,
-		maxZoom: 21
+		maxZoom: 21,
 		// Actual `maxZoom` value may be less, depending on imagery set / coverage area
 		// - 19~20 for all 'Aerial*'
 		// - 20 for 'Road' (Deprecated)
+
+		applyMaxNativeZoom: 'auto'
+		// try to determine maximum available zoom (for current location) on layer add.
+		// makes sense only for 'Aerial*' and 'Road' imagery sets.
 	},
 
 	initialize: function (key, options) {
@@ -36,7 +40,12 @@ L.BingLayer = L.TileLayer.extend({
 		}
 		L.TileLayer.prototype.initialize.call(this, null, options);
 
-		if (key) { this.options.key = key; }
+		options = this.options;
+		if (key) { options.key = key; }
+		if (options.applyMaxNativeZoom === 'auto' && !options.maxNativeZoom) {
+			options.applyMaxNativeZoom = options.type==='Road' ||
+				options.type.substring(0,6)==='Aerial';
+		}
 	},
 
 	tile2quad: function (x, y, z) {
@@ -59,7 +68,6 @@ L.BingLayer = L.TileLayer.extend({
 		};
 		return L.Util.template(this._url, data);
 	},
-
 
 	callRestService: function (request, callback, context) {
 		context = context || this;
@@ -134,6 +142,39 @@ L.BingLayer = L.TileLayer.extend({
 		return providers;
 	},
 
+	applyMaxNativeZoom: function (latlng) {
+		var options = this.options;
+		// https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata#basic-metadata-url
+		var request = this._makeApiUrl('Imagery/BasicMetadata', L.Util.template('{imagerySet}/{centerPoint}', {
+			imagerySet: options.type,
+			centerPoint: L.Util.template('{lat},{lng}', latlng)
+		}));
+		var zoomOffset = options.zoomOffset || 0;  // detectRetina sideeffects on maxZoom / maxNativeZoom
+		this._findVintage(request, options.maxZoom + zoomOffset, function (zoom) {
+			if (zoom) {
+				zoom -= zoomOffset;
+				var oldValue = options.maxNativeZoom || options.maxZoom;
+				options.maxNativeZoom = zoom;
+				var mapZoom = this._map && this._map.getZoom();
+				if (mapZoom &&
+					(zoom<oldValue && zoom<mapZoom || zoom>oldValue && mapZoom>oldValue)) {
+					this._resetView();
+				}
+			}
+		});
+		return this;
+	},
+
+	_findVintage: function (request, zoomLevel, callback, context) {
+		// there is no official way, so use heuristic: check `vintageStart` in metadata response
+		this.callRestService(request + '&zoomLevel='+zoomLevel, function (meta) {
+			if (meta.resourceSets[0].resources[0].vintageStart || zoomLevel === 0) {
+				return callback.call(context || this, zoomLevel);
+			}
+			this._findVintage(request, zoomLevel-1, callback, context);
+		});
+	},
+
 	_update: function (center) {
 		if (!this._url) { return; }
 		L.GridLayer.prototype._update.call(this, center);
@@ -172,6 +213,10 @@ L.BingLayer = L.TileLayer.extend({
 		//       https://docs.microsoft.com/en-us/bingmaps/getting-started/bing-maps-dev-center-help/understanding-bing-maps-transactions#rest-services
 		//       That's why it's important to defer it till BingLayer is actually added to map
 		this.loadMetadata();
+
+		if (this.options.applyMaxNativeZoom) {
+			this.applyMaxNativeZoom(map.getCenter());
+		}
 		L.GridLayer.prototype.onAdd.call(this, map);
 	},
 

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -131,6 +131,10 @@ L.BingLayer = L.TileLayer.extend({
 	},
 
 	onAdd: function (map) {
+		// Note: Metadata could be loaded earlier, on layer initialize,
+		//       but according to docs even such request is billable:
+		//       https://docs.microsoft.com/en-us/bingmaps/getting-started/bing-maps-dev-center-help/understanding-bing-maps-transactions#rest-services
+		//       That's why it's important to defer it till BingLayer is actually added to map
 		this.loadMetadata();
 		L.GridLayer.prototype.onAdd.call(this, map);
 	},

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -83,13 +83,11 @@ L.BingLayer = L.TileLayer.extend({
 	loadMetadata: function () {
 		if (this.metaRequested) { return; }
 		this.metaRequested = true;
-		var urlScheme = document.location.protocol === 'file:' ? 'http' :
-			document.location.protocol.slice(0, -1);
 		var options = this.options;
 		// https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata#complete-metadata-urls
-		var request = urlScheme + '://dev.virtualearth.net/REST/v1/Imagery/Metadata/' + options.type;
+		var request = 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' + options.type;
 		request += L.Util.getParamString({
-			UriScheme: urlScheme,
+			UriScheme: 'https',
 			include: 'ImageryProviders',
 			key: options.key,
 			culture: options.culture,

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -100,7 +100,7 @@ L.BingLayer = L.TileLayer.extend({
 			if (!r.imageUrl) { throw new Error('imageUrl not found in response'); }
 			if (r.imageUrlSubdomains) { options.subdomains = r.imageUrlSubdomains; }
 			this._providers = r.imageryProviders ? this._prepAttrBounds(r.imageryProviders) : [];
-			this._attributions = {};
+			this._attributions = [];
 			this._url = r.imageUrl;
 			if (options.retinaDpi && options.detectRetina && options.zoomOffset) {
 				this._url += '&dpi=' + options.retinaDpi;
@@ -135,26 +135,21 @@ L.BingLayer = L.TileLayer.extend({
 		var bounds = this._map.getBounds();
 		bounds = L.latLngBounds(bounds.getSouthWest().wrap(), bounds.getNorthEast().wrap());
 		var zoom = this._getZoomForUrl();
-		var attributions = {};
-		this._providers.forEach(function (provider) {
-			var attr = provider.attribution;
-			attributions[attr] = remove ? false : provider.coverageAreas.some(function (area) {
+		var attributions = this._providers.map(function (provider) {
+			return remove ? false : provider.coverageAreas.some(function (area) {
 				return zoom <= area.zoomMax && zoom >= area.zoomMin &&
 					bounds.intersects(area.bounds);
 			});
-			if (!attributions[attr]) { delete attributions[attr]; }
 		});
-		var attr;
-		for (attr in attributions) {
-			if (!this._attributions[attr]) {
-				attributionControl.addAttribution(attr);
+		attributions.forEach(function (a,i) {
+			if (a == this._attributions[i]) {
+				return;
+			} else if (a) {
+				attributionControl.addAttribution(this._providers[i].attribution);
+			} else {
+				attributionControl.removeAttribution(this._providers[i].attribution);
 			}
-		}
-		for (attr in this._attributions) {
-			if (!attributions[attr]) {
-				attributionControl.removeAttribution(attr);
-			}
-		}
+		}, this);
 		this._attributions = attributions;
 	},
 

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -80,16 +80,30 @@ L.BingLayer = L.TileLayer.extend({
 		document.body.appendChild(script);
 	},
 
+	_makeApiUrl: function (restApi, resourcePath, query) {
+		var baseAPIparams = {
+			version: 'v1',
+			restApi: restApi,
+			resourcePath: resourcePath
+		};
+		query = L.extend({
+			// errorDetail: true, // seems no effect
+			key: this.options.key
+		}, query);
+
+		// https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/base-url-structure
+		var template = 'https://dev.virtualearth.net/REST/{version}/{restApi}/{resourcePath}'; // ?queryParameters&key=BingMapsKey
+		return L.Util.template(template, baseAPIparams) + L.Util.getParamString(query);
+	},
+
 	loadMetadata: function () {
 		if (this.metaRequested) { return; }
 		this.metaRequested = true;
 		var options = this.options;
 		// https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata#complete-metadata-urls
-		var request = 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' + options.type;
-		request += L.Util.getParamString({
+		var request = this._makeApiUrl('Imagery/Metadata', options.type, {
 			UriScheme: 'https',
 			include: 'ImageryProviders',
-			key: options.key,
 			culture: options.culture,
 			style: options.style
 		});

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -103,6 +103,7 @@ L.BingLayer = L.TileLayer.extend({
 			if (options.retinaDpi && options.detectRetina && options.zoomOffset) {
 				this._url += '&dpi=' + options.retinaDpi;
 			}
+			this.fire('load', {meta: meta});
 			if (this._map) { this._update(); }
 		});
 	},

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -13,6 +13,9 @@ L.BingLayer = L.TileLayer.extend({
 		// https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes
 		culture: '',
 
+		// https://docs.microsoft.com/en-us/bingmaps/articles/custom-map-styles-in-bing-maps#custom-map-styles-in-the-rest-and-tile-services
+		style: '',
+
 		attribution: 'Bing',
 		minZoom: 1,
 		maxZoom: 21
@@ -75,7 +78,8 @@ L.BingLayer = L.TileLayer.extend({
 			UriScheme: urlScheme,
 			include: 'ImageryProviders',
 			key: this.options.key,
-			culture: this.options.culture
+			culture: this.options.culture,
+			style: this.options.style
 		});
 		var script = document.createElement('script');
 		script.type = 'text/javascript';

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -22,9 +22,13 @@ L.BingLayer = L.TileLayer.extend({
 	},
 
 	initialize: function (key, options) {
+		if (typeof key === 'object') {
+			options = key;
+			key = false;
+		}
 		L.Util.setOptions(this, options);
 
-		this._key = key;
+		if (key) { this.options.key = key; }
 		this._url = null;
 	},
 
@@ -70,7 +74,7 @@ L.BingLayer = L.TileLayer.extend({
 			jsonp: cbid,
 			UriScheme: urlScheme,
 			include: 'ImageryProviders',
-			key: this._key,
+			key: this.options.key,
 			culture: this.options.culture
 		});
 		var script = document.createElement('script');

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -8,7 +8,7 @@ L.BingLayer = L.TileLayer.extend({
 		// - Road (Deprecated), RoadOnDemand
 		// - CanvasDark, CanvasLight, CanvasGray
 		// not supported: Birdseye*, Streetside
-		type: 'RoadOnDemand',
+		type: 'Aerial', // to be changed on next major version!!
 
 		// https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes
 		culture: '',

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -105,7 +105,7 @@ L.BingLayer = L.TileLayer.extend({
 			if (options.retinaDpi && options.detectRetina && options.zoomOffset) {
 				this._url += '&dpi=' + options.retinaDpi;
 			}
-			this._update();
+			if (this._map) { this._update(); }
 		});
 	},
 
@@ -122,9 +122,9 @@ L.BingLayer = L.TileLayer.extend({
 	},
 
 	_update: function (center) {
-		if (!this._url || !this._map) { return; }
-		this._update_attribution();
+		if (!this._url) { return; }
 		L.GridLayer.prototype._update.call(this, center);
+		this._update_attribution();
 	},
 
 	_update_attribution: function (remove) {

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -8,7 +8,7 @@ L.BingLayer = L.TileLayer.extend({
 		// - Road (Deprecated), RoadOnDemand
 		// - CanvasDark, CanvasLight, CanvasGray
 		// not supported: Birdseye*, Streetside
-		type: 'Aerial', // to be changed on next major version!!
+		imagerySet: 'Aerial', // to be changed on next major version!!
 
 		// https://docs.microsoft.com/en-us/bingmaps/rest-services/common-parameters-and-types/supported-culture-codes
 		culture: '',
@@ -41,10 +41,12 @@ L.BingLayer = L.TileLayer.extend({
 		L.TileLayer.prototype.initialize.call(this, null, options);
 
 		options = this.options;
+		options.key = options.key || options.bingMapsKey;
+		options.imagerySet = options.imagerySet || options.type;
 		if (key) { options.key = key; }
 		if (options.applyMaxNativeZoom === 'auto' && !options.maxNativeZoom) {
-			options.applyMaxNativeZoom = options.type==='Road' ||
-				options.type.substring(0,6)==='Aerial';
+			options.applyMaxNativeZoom = options.imagerySet==='Road' ||
+				options.imagerySet.substring(0,6)==='Aerial';
 		}
 	},
 
@@ -109,7 +111,7 @@ L.BingLayer = L.TileLayer.extend({
 		this.metaRequested = true;
 		var options = this.options;
 		// https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata#complete-metadata-urls
-		var request = this._makeApiUrl('Imagery/Metadata', options.type, {
+		var request = this._makeApiUrl('Imagery/Metadata', options.imagerySet, {
 			UriScheme: 'https',
 			include: 'ImageryProviders',
 			culture: options.culture,
@@ -146,7 +148,7 @@ L.BingLayer = L.TileLayer.extend({
 		var options = this.options;
 		// https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata#basic-metadata-url
 		var request = this._makeApiUrl('Imagery/BasicMetadata', L.Util.template('{imagerySet}/{centerPoint}', {
-			imagerySet: options.type,
+			imagerySet: options.imagerySet,
 			centerPoint: L.Util.template('{lat},{lng}', latlng)
 		}));
 		var zoomOffset = options.zoomOffset || 0;  // detectRetina sideeffects on maxZoom / maxNativeZoom

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -16,6 +16,11 @@ L.BingLayer = L.TileLayer.extend({
 		// https://docs.microsoft.com/en-us/bingmaps/articles/custom-map-styles-in-bing-maps#custom-map-styles-in-the-rest-and-tile-services
 		style: '',
 
+		// https://blogs.bing.com/maps/2015/02/12/high-ppi-maps-now-available-in-the-bing-maps-ajax-control
+		// not documented in REST API docs, but working
+		// warning: deprecated imagery sets may not support some values (depending also on zoom level)
+		retinaDpi: 'd2',
+
 		attribution: 'Bing',
 		minZoom: 1,
 		maxZoom: 21
@@ -29,10 +34,9 @@ L.BingLayer = L.TileLayer.extend({
 			options = key;
 			key = false;
 		}
-		L.Util.setOptions(this, options);
+		L.TileLayer.prototype.initialize.call(this, null, options);
 
 		if (key) { this.options.key = key; }
-		this._url = null;
 	},
 
 	tile2quad: function (x, y, z) {
@@ -89,9 +93,10 @@ L.BingLayer = L.TileLayer.extend({
 	},
 
 	initMetadata: function (meta) {
+		var options = this.options;
 		var r = meta.resourceSets[0].resources[0];
 		if (!r.imageUrl) { throw new Error('imageUrl not found in response'); }
-		if (r.imageUrlSubdomains) { this.options.subdomains = r.imageUrlSubdomains; }
+		if (r.imageUrlSubdomains) { options.subdomains = r.imageUrlSubdomains; }
 		this._url = r.imageUrl;
 		this._providers = [];
 		if (r.imageryProviders) {
@@ -109,6 +114,9 @@ L.BingLayer = L.TileLayer.extend({
 					this._providers.push(coverage);
 				}
 			}
+		}
+		if (options.retinaDpi && options.detectRetina && options.zoomOffset) {
+			this._url += '&dpi=' + options.retinaDpi;
 		}
 		this._update();
 	},

--- a/layer/tile/Bing.js
+++ b/layer/tile/Bing.js
@@ -82,7 +82,8 @@ L.BingLayer = L.TileLayer.extend({
 
 	initMetadata: function (meta) {
 		var r = meta.resourceSets[0].resources[0];
-		this.options.subdomains = r.imageUrlSubdomains;
+		if (!r.imageUrl) { throw new Error('imageUrl not found in response'); }
+		if (r.imageUrlSubdomains) { this.options.subdomains = r.imageUrlSubdomains; }
 		this._url = r.imageUrl;
 		this._providers = [];
 		if (r.imageryProviders) {


### PR DESCRIPTION
Options:
- fix `culture` option for updated imagery sets
- fix `minZoom` / `maxZoom` options,
   add `applyMaxNativeZoom` method/option
- support `style` option
- support `detectRetina` option
- options are now compatible with https://github.com/digidem/leaflet-bing-layer

Constructor:
- `key` can be included in options

Misc updates and refactoring

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shramov/leaflet-plugins/288)
<!-- Reviewable:end -->
