### PR TITLE
L.Yandex: follow container's size changes

### DIFF
--- a/layer/tile/Yandex.js
+++ b/layer/tile/Yandex.js
@@ -80,7 +80,10 @@ L.Yandex = L.Layer.extend({
 
 	_setEvents: function (map) {
 		var events = {
-			move: this._update
+			move: this._update,
+			resize: function () {
+				this._yandex.container.fitToViewport();
+			}
 		};
 		if (this._zoomAnimated) {
 			events.zoomanim = this._animateZoom;


### PR DESCRIPTION
Was unintentionally broken in 3.1.0.
Fix #293.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shramov/leaflet-plugins/302)
<!-- Reviewable:end -->
